### PR TITLE
Added a message to canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <audio src="./snd/bloody_tears.mp3" preload="auto"></audio>
     <audio src="./snd/awake.mp3" preload="auto"></audio>
     <noscript>This game requires JavaScript to play. Please enable JavaScript!</noscript>
-    <canvas id="gameWorld" tabindex="1" width="1280" height="720"></canvas>
+    <canvas id="gameWorld" tabindex="1" width="1280" height="720">Your browser does not support HTML5 Canvas.</canvas>
 </body>
 </html>
 


### PR DESCRIPTION
This message displays when the browser does not support HTML5 canvas.
It's a change in the same vein as the <noscript> tags. Not necessary,
but I think it's a good detail.
Also props to GitHub app for deleting the g in 'changes'.
