### PR TITLE
Collision listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     <script type="text/javascript" src="./src/agents/knight.js"></script>
     <script type="text/javascript" src="./src/agents/block.js"></script>
     <script type="text/javascript" src="./src/agents/platform.js"></script>
+    <script type="text/javascript" src="./src/agents/enemy.js"></script>
 
     <link rel="icon" href="./img/icon.png">
 </head>

--- a/src/agents/enemy.js
+++ b/src/agents/enemy.js
@@ -27,5 +27,11 @@ Skeleton.prototype = {
     
     draw: function() {
         this.entity.draw();
+    },
+    
+    checkListeners: function(agent) {
+        if (agent.entity.controllable) {
+            this.entity.game.requestInputSend(agent, "damage", 1);
+        }
     }
 }

--- a/src/agents/enemy.js
+++ b/src/agents/enemy.js
@@ -1,7 +1,8 @@
 function Skeleton(game, AM, x, y) {
     this.entity = new Entity(game, x, y, 52, 60);
     
-    this.health = 6;
+    this.health = 3;
+    this.invulnerableFrames = 0;
     this.yVelocity = 0;
     this.xVelocity = 1;
     
@@ -18,6 +19,15 @@ function Skeleton(game, AM, x, y) {
 Skeleton.prototype = {
     
     update: function() {
+        if (this.invulnerableFrames > 0) {
+            this.invulnerableFrames--;
+        }
+        if (this.health <= 0) {
+            var index = this.entity.game.agents.indexOf(this);
+            this.entity.game.agents.splice(index, 1);
+        }
+        
+        
         if (this.xVelocity > 0) {
             this.entity.currentAnimation = 0;
         } else {
@@ -27,6 +37,15 @@ Skeleton.prototype = {
     
     draw: function() {
         this.entity.draw();
+    },
+    
+    readInput: function(input, modifier) {
+        if (input === "damage") {
+            if (this.invulnerableFrames === 0) {
+                this.invulnerableFrames = 30;
+                this.health--;
+            }
+        }
     },
     
     checkListeners: function(agent) {

--- a/src/agents/enemy.js
+++ b/src/agents/enemy.js
@@ -1,7 +1,20 @@
+var SKELETON_ATTR = {
+    STARTING_HEALTH: 3,
+    INVULNERABILITY_FRAMES: 40,
+}
+
+var SKELETON_ANIM = {
+    STANDING_RIGHT: 0,
+    STANDING_LEFT: 1,
+}
+
+/**
+  * Create a new Normal Skeleton.
+  */
 function Skeleton(game, AM, x, y) {
     this.entity = new Entity(game, x, y, 52, 60);
     
-    this.health = 3;
+    this.health = SKELETON_ATTR.STARTING_HEALTH;
     this.invulnerableFrames = 0;
     this.yVelocity = 0;
     this.xVelocity = 1;
@@ -13,7 +26,7 @@ function Skeleton(game, AM, x, y) {
     
     this.entity.addAnimation(skeletonRight);
     this.entity.addAnimation(skeletonLeft);
-    this.entity.setAnimation(0);
+    this.entity.setAnimation(SKELETON_ANIM.STANDING_RIGHT);
 }
 
 Skeleton.prototype = {
@@ -29,9 +42,9 @@ Skeleton.prototype = {
         
         
         if (this.xVelocity > 0) {
-            this.entity.currentAnimation = 0;
+            this.entity.currentAnimation = SKELETON_ANIM.STANDING_RIGHT;
         } else {
-            this.entity.currentAnimation = 1;
+            this.entity.currentAnimation = SKELETON_ANIM.STANDING_LEFT;
         }
     },
     
@@ -42,7 +55,7 @@ Skeleton.prototype = {
     readInput: function(input, modifier) {
         if (input === "damage") {
             if (this.invulnerableFrames === 0) {
-                this.invulnerableFrames = 30;
+                this.invulnerableFrames = SKELETON_ATTR.INVULNERABILITY_FRAMES;
                 this.health--;
             }
         }

--- a/src/agents/enemy.js
+++ b/src/agents/enemy.js
@@ -1,31 +1,31 @@
-var ENEMY_GLOBALS = {
-    WIDTH: 50,
-    HEIGHT: 50,
-    FRAME_DURATION: 1,
-}
-
-function Enemy(game, AM, x, y) {
-    this.entity = new Entity(game, x, y, ENEMY_GLOBALS.WIDTH, ENEMY_GLOBALS.HEIGHT);
-
-    var NormalState = new Animation(AM.getAsset("./img/forest-stage/forest block.png"), ENEMY_GLOBALS.WIDTH, ENEMY_GLOBALS.HEIGHT, ENEMY_GLOBALS.FRAME_DURATION, true);
-    NormalState.addFrame(0, 0);
-
-    this.entity.addAnimation(NormalState);
+function Skeleton(game, AM, x, y) {
+    this.entity = new Entity(game, x, y, 52, 60);
+    
+    this.health = 6;
+    this.yVelocity = 0;
+    this.xVelocity = 1;
+    
+    var skeletonRight = new Animation(AM.getAsset("./img/enemy/skeletonChaser mockup.png"), 52, 60, 0.05, true);
+    skeletonRight.addFrame(52, 0);
+    var skeletonLeft = new Animation(AM.getAsset("./img/enemy/skeletonChaser mockup.png"), 52, 60, 0.05, true);
+    skeletonLeft.addFrame(0, 0);
+    
+    this.entity.addAnimation(skeletonRight);
+    this.entity.addAnimation(skeletonLeft);
     this.entity.setAnimation(0);
 }
 
-Enemy.prototype = {
-
-    draw: function () {
-        this.entity.draw();
+Skeleton.prototype = {
+    
+    update: function() {
+        if (this.xVelocity > 0) {
+            this.entity.currentAnimation = 0;
+        } else {
+            this.entity.currentAnimation = 1;
+        }
     },
-
-    update: function () {
+    
+    draw: function() {
+        this.entity.draw();
     }
 }
-
-function Skeleton(game, AM, x, y) {
-    Enemy.call(game, AM, x, y);
-}
-
-Skeleton.prototype = Enemy.prototype;

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -216,6 +216,10 @@ Knight.prototype.readInput = function(input, modifier) {
         this.readInput("none");
     }
     
+    if (input === "damage") {
+        console.log(modifier);
+    }
+    
     //No-clip activation/deactivation
     if (input === 'n') {
         if(this.entity.game.DEBUG_MODE === 1) {

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -52,7 +52,9 @@ function Knight(game, AM, x, y) {
     this.velocity = 0;
     this.direction = KNIGHT_DIR.RIGHT;
     this.canJump = true;
+    
     this.invulnerableFrames = 0;
+    this.health = 4;
 
     var KnightRestRight = new Animation(AM.getAsset("./img/knight/knight standing.png"),
         KNIGHT_SIZE.REST_WIDTH, KNIGHT_SIZE.REST_HEIGHT, KNIGHT_ANIM.FRAME_DURATION, true);
@@ -102,6 +104,11 @@ Knight.prototype.draw = function () {
  * from falling and jumping.
  */
 Knight.prototype.update = function() {
+    
+    if(this.health <= 0) {
+        this.health = 4;
+        this.entity.game.respawnPlayer(this);
+    }
     
     if(this.invulnerableFrames > 0) {
         this.invulnerableFrames--;
@@ -226,6 +233,7 @@ Knight.prototype.readInput = function(input, modifier) {
         if (this.invulnerableFrames === 0) {
             console.log(modifier);
             this.invulnerableFrames = 30;
+            this.health--;
             
             if (this.direction === KNIGHT_DIR.LEFT) {
                 this.entity.game.requestMove(this, 40, 0);

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -163,7 +163,7 @@ Knight.prototype.jump = function() {
 /**
  * Request the agent to process an input.
  */
-Knight.prototype.readInput = function(input) {
+Knight.prototype.readInput = function(input, modifier) {
     if (input === "down") {
         this.entity.game.requestMove(this, 0, KNIGHT_PHYSICS.PRESS_DOWN_SPEED);
     } 

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -131,7 +131,7 @@ Knight.prototype.update = function() {
     
     //If downwards velocity is present, request to move the agent with it.
     if(this.velocity !== 0) {
-        this.entity.game.requestMove(this.entity, 0, this.velocity);
+        this.entity.game.requestMove(this, 0, this.velocity);
         if(this.velocity > 0) {
             if(this.direction === KNIGHT_DIR.RIGHT) {
                 this.entity.setAnimation(KNIGHT_ANIM.FALLING_RIGHT);
@@ -165,7 +165,7 @@ Knight.prototype.jump = function() {
  */
 Knight.prototype.readInput = function(input) {
     if (input === "down") {
-        this.entity.game.requestMove(this.entity, 0, KNIGHT_PHYSICS.PRESS_DOWN_SPEED);
+        this.entity.game.requestMove(this, 0, KNIGHT_PHYSICS.PRESS_DOWN_SPEED);
     } 
     if (input === "up") {
         //Add upwards velocity if the player is holding up while jumping.
@@ -174,7 +174,7 @@ Knight.prototype.readInput = function(input) {
         
         //Allows no-clip debugging.
         if(!this.entity.fallable) {
-            this.entity.game.requestMove(this.entity, 0, -10)
+            this.entity.game.requestMove(this, 0, -10)
         }
     } 
     if (input === "left") {
@@ -183,7 +183,7 @@ Knight.prototype.readInput = function(input) {
             //An agent should only walk if it is not in the air.
             this.entity.setAnimation(KNIGHT_ANIM.WALKING_LEFT);
         }
-        this.entity.game.requestMove(this.entity, -KNIGHT_PHYSICS.RUNNING_SPEED, 0);
+        this.entity.game.requestMove(this, -KNIGHT_PHYSICS.RUNNING_SPEED, 0);
     }
     if(input === "right") {
         this.direction = KNIGHT_DIR.RIGHT;
@@ -191,7 +191,7 @@ Knight.prototype.readInput = function(input) {
             //An agent should only walk if it is not in the air.
             this.entity.setAnimation(KNIGHT_ANIM.WALKING_RIGHT);
         }
-        this.entity.game.requestMove(this.entity, KNIGHT_PHYSICS.RUNNING_SPEED, 0);
+        this.entity.game.requestMove(this, KNIGHT_PHYSICS.RUNNING_SPEED, 0);
     }
     if (input === "none") {
         if(this.direction === KNIGHT_DIR.RIGHT) {

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -52,6 +52,7 @@ function Knight(game, AM, x, y) {
     this.velocity = 0;
     this.direction = KNIGHT_DIR.RIGHT;
     this.canJump = true;
+    this.invulnerableFrames = 0;
 
     var KnightRestRight = new Animation(AM.getAsset("./img/knight/knight standing.png"),
         KNIGHT_SIZE.REST_WIDTH, KNIGHT_SIZE.REST_HEIGHT, KNIGHT_ANIM.FRAME_DURATION, true);
@@ -101,6 +102,11 @@ Knight.prototype.draw = function () {
  * from falling and jumping.
  */
 Knight.prototype.update = function() {
+    
+    if(this.invulnerableFrames > 0) {
+        this.invulnerableFrames--;
+    }
+    
     if(!this.entity.fallable) return;
     
     if (!this.entity.game.checkBottomCollision(this.entity)) {
@@ -217,7 +223,18 @@ Knight.prototype.readInput = function(input, modifier) {
     }
     
     if (input === "damage") {
-        console.log(modifier);
+        if (this.invulnerableFrames === 0) {
+            console.log(modifier);
+            this.invulnerableFrames = 30;
+            
+            if (this.direction === KNIGHT_DIR.LEFT) {
+                this.entity.game.requestMove(this, 40, 0);
+                this.velocity = -5;
+            } else {
+                this.entity.game.requestMove(this, -40, 0);
+                this.velocity = -5;
+            }
+        }
     }
     
     //No-clip activation/deactivation

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -235,7 +235,12 @@ Knight.prototype.readInput = function(input, modifier) {
         
         if (this.attackFrames <= 0) {
             this.attackFrames = 24;
-            var newAttack = new SwordHitbox(this.entity.game, this.entity.x + this.entity.width, this.entity.y);
+            if(this.direction === KNIGHT_DIR.RIGHT) {
+                var newAttack = new SwordHitbox(this.entity.game, this.entity.x + this.entity.width + 1, this.entity.y);
+            } else {
+                var newAttack = new SwordHitbox(this.entity.game, this.entity.x - this.entity.width - 51, this.entity.y);
+            }
+            
             this.entity.game.addAgent(newAttack);
         }
     }
@@ -296,6 +301,7 @@ Knight.prototype.readInput = function(input, modifier) {
 
 function SwordHitbox(game, x, y) {
     this.entity = new Entity(game, x , y, 50, 50);
+    this.entity.moveable = true;
     this.framesRemaining = 24;
 }
 
@@ -308,6 +314,7 @@ SwordHitbox.prototype = {
             var index = this.entity.game.agents.indexOf(this);
             this.entity.game.agents.splice(index, 1);
         }
+        this.entity.game.requestMove(this, 0, 0);
     },
     
     draw: function() {

--- a/src/agents/platform.js
+++ b/src/agents/platform.js
@@ -58,18 +58,18 @@ Platform.prototype = {
                 this.lastMoveOriginY = this.entity.y;
             }
             //Move the platform by the amount requested by the movement pattern.
-            var entitiesToDrag = this.entity.game.checkTopCollision(this.entity);
+            var agentsToDrag = this.entity.game.checkTopCollision(this.entity);
             
             if (this.currentMovePattern < this.movePatterns.length) {
-                this.entity.game.requestMove(this.entity, 
+                this.entity.game.requestMove(this, 
                                              this.movePatterns[this.currentMovePattern][1], 
                                              this.movePatterns[this.currentMovePattern][3]);
                 
                 //Only vertically drag riding entities downwards. Gravity will take care of the rest.
                 var downwardsDrag = Math.max(0, this.movePatterns[this.currentMovePattern][3]);
                 
-                for (var i = 0; i < entitiesToDrag.length; i++) {
-                    this.entity.game.requestMove(entitiesToDrag[i], 
+                for (var i = 0; i < agentsToDrag.length; i++) {
+                    this.entity.game.requestMove(agentsToDrag[i], 
                                              this.movePatterns[this.currentMovePattern][1], 
                                              downwardsDrag);
                 }

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -235,6 +235,12 @@ GameEngine.prototype = {
                 }
                 break;
             }
+            if (typeof agent.checkListeners === 'function') {
+                agent.checkListeners(this.agents[i]);
+            }
+            if (typeof this.agents[i].checkListeners === 'function') {
+                this.agents[i].checkLIsteners(agent);
+            }
         }
 
         //Move the entity.

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -233,13 +233,14 @@ GameEngine.prototype = {
                     amountX = adjustedX;
                     amountY = adjustedY;
                 }
+                
+                if (typeof agent.checkListeners === 'function') {
+                    agent.checkListeners(this.agents[i]);
+                }
+                if (typeof this.agents[i].checkListeners === 'function') {
+                    this.agents[i].checkListeners(agent);
+                }
                 break;
-            }
-            if (typeof agent.checkListeners === 'function') {
-                agent.checkListeners(this.agents[i]);
-            }
-            if (typeof this.agents[i].checkListeners === 'function') {
-                this.agents[i].checkLIsteners(agent);
             }
         }
 
@@ -343,6 +344,12 @@ GameEngine.prototype = {
             }
         }
         return topCollision;
+    },
+    
+    requestInputSend: function (agent, input, modifier) {
+        if (typeof agent.readInput === 'function') {
+            agent.readInput(input, modifier);
+        }
     }
 }
 

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -350,6 +350,12 @@ GameEngine.prototype = {
         if (typeof agent.readInput === 'function') {
             agent.readInput(input, modifier);
         }
+    },
+    
+    //TODO: Add the player as a field so that this is parameter-less.
+    respawnPlayer: function (agent) {
+        agent.entity.x = this.stages[this.currentStage].spawnX;
+        agent.entity.y = this.stages[this.currentStage].spawnY;
     }
 }
 

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -85,6 +85,9 @@ GameEngine.prototype = {
                 case 78: //N
                     that.pressN = true;
                     break;
+                case 32: //SPACE
+                    that.pressSpace = true;
+                    break;
             }
             e.preventDefault();
         }, false);
@@ -106,6 +109,9 @@ GameEngine.prototype = {
                     break;
                 case 78: //N
                     that.pressN = false;
+                    break;
+                case 32: //SPACE
+                    that.pressSpace = false;
                     break;
             }
             //console.log(e.which);
@@ -380,12 +386,14 @@ GameEngine.prototype.loop = function () {
             if(this.pressUp) this.agents[i].readInput("up");
             if(this.pressLeft) this.agents[i].readInput("left");
             if(this.pressN) this.agents[i].readInput('n');
+            if(this.pressSpace) this.agents[i].readInput("space");
             
             if(!this.pressUp) this.agents[i].readInput("up_released");
             if(!this.pressLeft) this.agents[i].readInput("left_released");
             if(!this.pressRight) this.agents[i].readInput("right_released");
+            if(!this.pressSpace) this.agents[i].readInput("space_released");
             
-            if(!this.pressLeft && !this.pressRight && !this.pressDown && !this.pressUp) this.agents[i].readInput("none");
+            if(!this.pressLeft && !this.pressRight && !this.pressDown && !this.pressUp && !this.pressSpace) this.agents[i].readInput("none");
         }
     }
     

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -160,7 +160,6 @@ GameEngine.prototype = {
         var newRight = newLeft + entity.width;
         var newTop = entity.y + amountY;
         var newBottom = newTop + entity.height;
-
         for (var i = 0; i < this.agents.length; i++) {
             if (!entity.collidable) break; //Non-collidable; skip the following collision tests.
 

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -145,7 +145,9 @@ GameEngine.prototype = {
      * Move an entity by a requested amount after checking for collision.
      * If a collision is detected, move the entity in a way that a collision does not occur.
      */
-    requestMove: function (entity, amountX, amountY) {
+    requestMove: function (agent, amountX, amountY) {
+        var entity = agent.entity;
+        
         if (!entity.moveable) return;
         //Calculate the new sides of the moving entity.
         var newLeft = entity.x + amountX;
@@ -226,7 +228,7 @@ GameEngine.prototype = {
                 if(other.controllable) {
                     //If the player is in the way, just move them over.
                     //TODO: Add movement priorities.
-                    this.requestMove(other, amountX, amountY);
+                    this.requestMove(this.agents[i], amountX, amountY);
                 } else {
                     amountX = adjustedX;
                     amountY = adjustedY;
@@ -257,7 +259,7 @@ GameEngine.prototype = {
         if (entity.respawnable && entity.y > this.stages[this.currentStage].stageHeight + 100) {
             entity.x = this.stages[this.currentStage].spawnX;
             entity.y = this.stages[this.currentStage].spawnY;
-            this.requestMove(entity, 0, 0); //resets camera
+            this.requestMove(agent, 0, 0); //resets camera
             //This camera reset should put the camera on the player instead.
         }
     },
@@ -330,7 +332,7 @@ GameEngine.prototype = {
             //If both are true, then the entity is directly below the other.
             if (aboveEntity) {
                 if (entity.y >= other.y && entity.y <= other.y + other.height + 1) {
-                    topCollision.push(other);
+                    topCollision.push(this.agents[i]);
                 }
             }
         }

--- a/src/main.js
+++ b/src/main.js
@@ -89,7 +89,7 @@ AM.downloadAll(function () {
     platform.addMovePattern(400, 1, 0, 0);
     platform.addMovePattern(0, 0, 200, -1);
     platform.addMovePattern(400, -1, 0, 0);
-    forestStage.entityList.push(platform);
+    //forestStage.entityList.push(platform);
     platform.addMovePattern(0, 0, 200, 1);
     
     var skeleton = new Skeleton(gameEngine, AM, 500, 2040);

--- a/src/main.js
+++ b/src/main.js
@@ -89,8 +89,8 @@ AM.downloadAll(function () {
     platform.addMovePattern(400, 1, 0, 0);
     platform.addMovePattern(0, 0, 200, -1);
     platform.addMovePattern(400, -1, 0, 0);
-    //forestStage.entityList.push(platform);
     platform.addMovePattern(0, 0, 200, 1);
+    forestStage.entityList.push(platform);
     
     var skeleton = new Skeleton(gameEngine, AM, 500, 2040);
     forestStage.entityList.push(skeleton);

--- a/src/main.js
+++ b/src/main.js
@@ -56,6 +56,8 @@ AM.queueDownload("./img/knight/knight standing.png");
 AM.queueDownload("./img/knight/knight jump draft flipped.png");
 AM.queueDownload("./img/knight/knight run draft flipped.png");
 AM.queueDownload("./img/knight/knight standing flipped.png");
+AM.queueDownload("./img/knight/knight attack draft.png");
+AM.queueDownload("./img/knight/knight attack draft flipped.png");
 AM.queueDownload("./img/forest-stage/forest sky.png");
 AM.queueDownload("./img/forest-stage/forest trees.png");
 AM.queueDownload("./img/forest-stage/forest block.png");

--- a/src/main.js
+++ b/src/main.js
@@ -97,5 +97,5 @@ AM.downloadAll(function () {
     BGM.hellBossFinal.play();
 
     gameEngine.start();
-    gameEngine.requestMove(knight.entity, RM_GLOBALS.FOREST_STAGE.KNIGHT_SPAWN_X, RM_GLOBALS.FOREST_STAGE.KNIGHT_SPAWN_Y); //Reset camera
+    gameEngine.requestMove(knight, RM_GLOBALS.FOREST_STAGE.KNIGHT_SPAWN_X, RM_GLOBALS.FOREST_STAGE.KNIGHT_SPAWN_Y); //Reset camera
 });

--- a/src/main.js
+++ b/src/main.js
@@ -92,7 +92,7 @@ AM.downloadAll(function () {
     forestStage.entityList.push(platform);
     platform.addMovePattern(0, 0, 200, 1);
     
-    var skeleton = new Skeleton(gameEngine, AM, 350, 2040);
+    var skeleton = new Skeleton(gameEngine, AM, 500, 2040);
     forestStage.entityList.push(skeleton);
     
     gameEngine.addStage(forestStage);

--- a/src/main.js
+++ b/src/main.js
@@ -59,6 +59,7 @@ AM.queueDownload("./img/knight/knight standing flipped.png");
 AM.queueDownload("./img/forest-stage/forest sky.png");
 AM.queueDownload("./img/forest-stage/forest trees.png");
 AM.queueDownload("./img/forest-stage/forest block.png");
+AM.queueDownload("./img/enemy/skeletonChaser mockup.png")
 
 AM.queueStageDownload("./txt/forest-stage.txt");
 
@@ -88,6 +89,9 @@ AM.downloadAll(function () {
     platform.addMovePattern(400, -1, 0, 0);
     forestStage.entityList.push(platform);
     platform.addMovePattern(0, 0, 200, 1);
+    
+    var skeleton = new Skeleton(gameEngine, AM, 350, 2040);
+    forestStage.entityList.push(skeleton);
     
     gameEngine.addStage(forestStage);
 


### PR DESCRIPTION
Enough has been added that I think it would be a good idea to go ahead and merge back in.

Added features include:
-Skeleton.js implemented (it currently just stands in place like a pro)
-If the player collides with the skeleton, they take damage and are knocked back.
-The player can attack by pressing space.
-The attack spawns a sword hitbox that does damage to any enemy it touches.
-The player respawns if they take enough damage; the skeleton disappears.

As discussed, upon a collision, game engine tells both colliding agents to check their listeners. So if the player and a Skeleton collides, the Skeleton has a listener for a player collision, where it requests Game Engine to tell the player to take damage. A similar process occurs for the sword hitbox.
