### PR TITLE
Animation changes

### DIFF
--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -94,9 +94,9 @@ function Knight(game, AM, x, y) {
         KNIGHT_SIZE.JUMP_WIDTH, KNIGHT_SIZE.JUMP_HEIGHT, KNIGHT_ANIM.FRAME_DURATION, true);
     KnightFallLeft.addFrame(KNIGHT_SIZE.JUMP_WIDTH, 0);
     
-    var KnightAttackRight = new Animation(AM.getAsset("./img/knight/knight attack.png"), 90, 70, 0.085, true);
+    var KnightAttackRight = new Animation(AM.getAsset("./img/knight/knight attack.png"), 90, 70, 0.085, true, 0, -19);
     KnightAttackRight.addFrameBatch(0, 0, 8);
-    var KnightAttackLeft = new Animation(AM.getAsset("./img/knight/knight attack flipped.png"), 90, 70, 0.085, true);
+    var KnightAttackLeft = new Animation(AM.getAsset("./img/knight/knight attack flipped.png"), 90, 70, 0.085, true, -35, -19);
     KnightAttackLeft.addFrameBatch(0, 0, 8);
     
     this.entity.addAnimation(KnightRestRight);

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -6,6 +6,8 @@ var KNIGHT_SIZE = {
     WALK_HEIGHT: 52,
     JUMP_WIDTH: 47,
     JUMP_HEIGHT: 55,
+    ATTACK_OFFSET_Y: -19,
+    ATTACK_LEFT_OFFSET_X: -40,
 }
 
 //Animation Constants
@@ -93,9 +95,10 @@ function Knight(game, AM, x, y) {
         KNIGHT_SIZE.JUMP_WIDTH, KNIGHT_SIZE.JUMP_HEIGHT, KNIGHT_ANIM.FRAME_DURATION, true);
     KnightFallLeft.addFrame(KNIGHT_SIZE.JUMP_WIDTH, 0);
     
-    var KnightAttackRight = new Animation(AM.getAsset("./img/knight/knight attack.png"), 90, 70, 0.085, false, 0, -19);
+    var KnightAttackRight = new Animation(AM.getAsset("./img/knight/knight attack.png"), 90, 70, 0.085, false, 0, KNIGHT_SIZE.ATTACK_OFFSET_Y);
     KnightAttackRight.addFrameBatch(0, 0, 8);
-    var KnightAttackLeft = new Animation(AM.getAsset("./img/knight/knight attack flipped.png"), 90, 70, 0.085, false, -40, -19);
+    var KnightAttackLeft = new Animation(AM.getAsset("./img/knight/knight attack flipped.png"), 90, 70, 0.085, false,
+                                         KNIGHT_SIZE.ATTACK_LEFT_OFFSET_X, KNIGHT_SIZE.ATTACK_OFFSET_Y);
     KnightAttackLeft.addFrameBatch(0, 0, 8);
     
     this.entity.addAnimation(KnightRestRight);
@@ -254,7 +257,8 @@ Knight.prototype.readInput = function(input, modifier) {
             if(this.direction === KNIGHT_DIR.RIGHT) {
                 var newAttack = new SwordHitbox(this.entity.game, this.entity.x + this.entity.width + 1, this.entity.y, this);
             } else {
-                var newAttack = new SwordHitbox(this.entity.game, this.entity.x - this.entity.width - 51, this.entity.y, this);
+                var newAttack = new SwordHitbox(this.entity.game, this.entity.x - this.entity.width - 51,
+                                                this.entity.y, this);
             }
             
             this.entity.game.addAgent(newAttack);

--- a/src/animation.js
+++ b/src/animation.js
@@ -4,8 +4,9 @@
  * frameHeight: The height of each frame.
  * frameDuration: The length in time that each frame should last.
  * loop: Set to true if the animation should repeat once it is over.
+ * offsetX/Y: Optional offsets for how the animation is drawn to the screen.
  */
-function Animation(spriteSheet, frameWidth, frameHeight, frameDuration, loop) {
+function Animation(spriteSheet, frameWidth, frameHeight, frameDuration, loop, offsetX, offsetY) {
     this.elapsedTime = 0;   
     this.frames = [];
     this.multiframeArray = [];
@@ -15,6 +16,13 @@ function Animation(spriteSheet, frameWidth, frameHeight, frameDuration, loop) {
     this.frameWidth = frameWidth;
     this.frameHeight = frameHeight;
     this.frameDuration = frameDuration;
+    
+    //Set offsets to 0 if they were not provided.
+    if (offsetX) this.offsetX = offsetX;
+    else this.offsetX = 0;
+    
+    if (offsetY) this.offsetY = offsetY;
+    else this.offsetY = 0;
 }
 
 Animation.prototype = {
@@ -132,7 +140,7 @@ Animation.prototype = {
             ctx.drawImage(this.spriteSheet,
                      xStart, yStart,  // source from sheet
                      this.frameWidth, this.frameHeight,
-                     x, y,
+                     x + this.offsetX, y + this.offsetY,
                      this.frameWidth,
                      this.frameHeight);
         } else {

--- a/src/animation.js
+++ b/src/animation.js
@@ -166,5 +166,13 @@ Animation.prototype = {
     //Return whether or not the animation has finished.
     isDone : function () {
         return (this.currentFrame() >= this.frames.length / 2);
-    }
+    },
+    
+    /*
+     * Return whether or not the animation is on its final frame.
+     * This indicates that the next frame animated will need to be from a different source.
+     */
+    isFinalFrame : function () {
+        return (this.currentFrame() + 1 >= this.frames.length / 2);
+}
 }

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -114,6 +114,10 @@ GameEngine.prototype = {
                 case 32: //SPACE
                     that.pressSpace = true;
                     break;
+                //DEBUG ONLY, allows you to ping your location to the console.
+                case 66: //B
+                    console.log("Current Location: " + that.playerAgent.entity.x +", " + that.playerAgent.entity.y);
+                    break
             }
             e.preventDefault();
         }, false);


### PR DESCRIPTION
- Optional offset parameters added to creating an animation.
- Offset added for knight's attack animation-- looks good now!
- Added isFinalFrame to Animation, for use by entities to know when they should switch animations/states. isDone returns true only AFTER the final frame has animated, which is useful when an Animation is figuring out which frame to display next. However, for things like entities which want to react as soon as an animation finishes, this occurs a frame too late.
- Knight now checks its current animation to determine if it is currently attacking. This way, the in-game effects of the attack will always sync up with what is being displayed.
- The sword hitbox now accepts a source (the knight), and checks if its source is attacking to determine if it should remove itself from the world.
