### PR TITLE
Hotfix

### DIFF
--- a/src/agents/enemy.js
+++ b/src/agents/enemy.js
@@ -140,8 +140,7 @@ Skeleton.prototype = {
                 this.invulnerableFrames = SKELETON_ATTR.INVULNERABILITY_FRAMES;
                 this.health--;
                 if (this.health <= 0) {
-                    var index = this.entity.game.agents.indexOf(this);
-                    this.entity.game.agents.splice(index, 1);
+                    this.entity.removeFromWorld = true;
                 } else {
                     this.confused = true;
                 }
@@ -189,11 +188,7 @@ Archer.prototype.update = function () {
     }
 
     if (this.health <= 0) {
-        this.removeFromWorld = true;
-        var index = this.stage.entityList.indexOf(this);
-        this.stage.entityList.splice(index, 1);
-        index = this.stage.enemies.indexOf(this);
-        this.stage.enemies.splice(index, 1);
+        this.entity.removeFromWorld = true;
         return;
     }
 

--- a/src/agents/forest-boss.js
+++ b/src/agents/forest-boss.js
@@ -272,18 +272,13 @@ ForestBoss.prototype = {
         if (this.phase === 2) this.currentAttackAnim = FB_ANIM.WIDE;
     },
     
-    //Remove the Forest Boss arms, core, and the controller from the game engine.
+    //Remove the Forest Boss arms, core, and the controller from world and switch the music back..
     selfDestruct: function () {
         for (var i = 0; i < this.arms.length; i++) {
-            var index = this.entity.game.agents.indexOf(this.arms[i]);
-            this.entity.game.agents.splice(index, 1);
+            this.arms[i].entity.removeFromWorld = true;
         }
-        
-        var index = this.entity.game.agents.indexOf(this.core);
-        this.entity.game.agents.splice(index, 1);
-        
-        index = this.entity.game.agents.indexOf(this);
-        this.entity.game.agents.splice(index, 1);
+        this.core.entity.removeFromWorld = true;
+        this.entity.removeFromWorld = true;
         
         var originalBGM = this.entity.game.stages[this.entity.game.currentStage].stageMusic;
         this.entity.game.switchMusic(originalBGM);

--- a/src/entity.js
+++ b/src/entity.js
@@ -20,6 +20,8 @@ function Entity(game, x, y, width, height) {
     this.camerable = false;
     this.respawnable = false;
     this.collidable = true;
+    
+    this.removeFromWorld = false;
 }
 
 Entity.prototype = {

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -181,6 +181,10 @@ GameEngine.prototype = {
     //Entities should check for input when updated here
     update : function () {
         for (var i = 0; i < this.agents.length; i++) {
+            if (this.agents[i].entity.removeFromWorld) {
+                this.agents.splice(i, 1);
+                continue;
+            }
             this.agents[i].update();
         }
 

--- a/src/main.js
+++ b/src/main.js
@@ -100,8 +100,8 @@ AM.downloadAll(function () {
     forestStage.entityList.push(firstPlatform);
 
     var secondPlatform = new Platform(gameEngine, AM, 3200, 1300, 4, 1);
-    secondPlatform.addMovePattern(450, -1, 0, 0);
-    secondPlatform.addMovePattern(450, 1, 0, 0);
+    secondPlatform.addMovePattern(450, -3, 0, 0);
+    secondPlatform.addMovePattern(450, 3, 0, 0);
     forestStage.entityList.push(secondPlatform);
     
     var bossCameraFocus = new FocusTrigger(gameEngine, AM, 3675, 1900);

--- a/src/main.js
+++ b/src/main.js
@@ -95,8 +95,8 @@ AM.downloadAll(function () {
     forestStage.entityList.push(knight);
     
     var firstPlatform = new Platform(gameEngine, AM, 2650, 650, 4, 1);
-    firstPlatform.addMovePattern(350, 1, 0, 0);
-    firstPlatform.addMovePattern(350, -1, 0, 0);
+    firstPlatform.addMovePattern(350, 2, 0, 0);
+    firstPlatform.addMovePattern(350, -2, 0, 0);
     forestStage.entityList.push(firstPlatform);
 
     var secondPlatform = new Platform(gameEngine, AM, 3200, 1300, 4, 1);


### PR DESCRIPTION
Solves a game-locking bug that occurred after killing an enemy.
Problem was due to the enemy removing themselves from the agents list and then another agent referencing them afterwards. Not sure why this only became a problem only now.
Solved by re-implementing removeFromWorld, where an entity can be flagged for deletion upon the next update pass.
