### PR TITLE
Knight refactor

### DIFF
--- a/src/agents/enemy.js
+++ b/src/agents/enemy.js
@@ -108,10 +108,10 @@ Skeleton.prototype = {
 
         //Skeletons should only do math if they are not confused
         if (!this.confused) {
-            var player = this.entity.game.playerAgent.entity;
-            if (this.entity.game.playerAgent.yVelocity === 0) {
+            var player = this.entity.game.playerAgent;
+            if (player.yVelocity === 0) {
 
-                var knightPoint = this.entity.game.playerAgent.centerPoint;
+                var knightPoint = player.entity.getCenter();
 
                 var skeletonPoint = {
                     x: (this.entity.x + (this.entity.width) / 2),
@@ -216,7 +216,7 @@ Wisp.prototype = {
             this.invulnerableFrames--;
         }
 
-        var knightPoint = this.entity.game.playerAgent.centerPoint;
+        var knightPoint = this.entity.game.playerAgent.entity.getCenter();
 
         var wispPoint = {
             x: (this.entity.x + (this.entity.width) / 2),
@@ -321,7 +321,7 @@ Archer.prototype = {
 
     update: function () {
 
-        var knightPoint = this.entity.game.playerAgent.centerPoint;
+        var knightPoint = this.entity.game.playerAgent.entity.getCenter();
 
         var archerPoint = {
             x: this.entity.x + this.entity.width / 2,

--- a/src/agents/forest-boss.js
+++ b/src/agents/forest-boss.js
@@ -468,7 +468,7 @@ ForestBossArm.prototype = {
 function ForestBossCore(game, AM, x, y, callback) {
     this.entity = new Entity(game, x, y, 50, 0);
     this.entity.moveable = true;
-    this.entity.intangible = true;
+    //this.entity.intangible = true;
     this.entity.pushesOnly = true;
     this.arm;
     this.callback = callback;
@@ -503,12 +503,17 @@ ForestBossCore.prototype = {
             animation.frameHeight += moveUp;
             this.entity.game.requestMove(this, 0, -1 * moveUp);
             this.entity.height += moveUp;
+            
+            //By making the core intangible after it finishes rising, it pops up the player
+            //momentarily but otherwise does not impede them.
+            if (moveUp === 0) this.entity.intangible = true;
+            else this.entity.intangible = false;
         } else {
             //Repeat a similar process as moving up.
             var moveDown = Math.min(10, animation.frameHeight);
             animation.frameHeight -= moveDown;
-            this.entity.game.requestMove(this, 0, moveDown);
             this.entity.height -= moveDown;
+            this.entity.game.requestMove(this, 0, moveDown);
         }
         
         //If the core has emerged, make it collidable.

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -71,6 +71,7 @@ function Knight(game, AM, x, y) {
     this.direction = KNIGHT_DIR.RIGHT;
     this.canJump = true;
     this.canMove = true;
+    this.noclip = false;
 
     this.invulnerableFrames = 0;
     this.attacking = false;
@@ -146,12 +147,9 @@ Knight.prototype.findYourCenter = function () {
 
 /**
  * Update the Knight agent.
- * As of right now, this only includes accounting for velocity and movement
- * from falling and jumping.
  */
 Knight.prototype.update = function() {
 
-    this.attacking = false;
     var currentAnimation = this.entity.currentAnimation;
 
     if (currentAnimation === KNIGHT_ANIM.ATTACK_RIGHT ||
@@ -159,6 +157,7 @@ Knight.prototype.update = function() {
         if (!this.entity.animationList[currentAnimation].isFinalFrame()) {
             this.attacking = true;
         } else {
+            this.attacking = false;
             this.readInput("none");
         }
     }
@@ -168,8 +167,6 @@ Knight.prototype.update = function() {
     if(this.invulnerableFrames > 0) {
         this.invulnerableFrames--;
     }
-
-    if(!this.entity.fallable) return;
 
     if (this.entity.game.getBottomCollisions(this).length === 0) {
         //If there is no bottom collision, then the agent is in the air, and should accelerate downwards.
@@ -252,7 +249,7 @@ Knight.prototype.readInput = function(input, modifier) {
         this.jump();
 
         //Allows no-clip debugging.
-        if(!this.entity.fallable) {
+        if(this.noclip) {
             this.entity.game.requestMove(this, 0, -10)
         }
     }
@@ -371,7 +368,7 @@ Knight.prototype.readInput = function(input, modifier) {
     //No-clip activation/deactivation
     if (input === 'n') {
         if(this.entity.game.DEBUG_MODE === 1) {
-            this.entity.fallable = !this.entity.fallable;
+            this.noclip = !this.noclip;
             this.entity.collidable = !this.entity.collidable;
         }
     }

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -137,9 +137,13 @@ Knight.prototype.draw = function (cameraX, cameraY) {
  * Update the Knight agent.
  */
 Knight.prototype.update = function() {
+    
+    if(this.invulnerableFrames > 0) {
+        this.invulnerableFrames--;
+    }
 
-    var currentAnimation = this.entity.currentAnimation;
-
+    //Update the knight's attack state.
+    var currentAnimation = this.entity.currentAnimation;   
     if (currentAnimation === KNIGHT_ANIM.ATTACK_RIGHT ||
         currentAnimation === KNIGHT_ANIM.ATTACK_LEFT) {
         if (!this.entity.animationList[currentAnimation].isFinalFrame()) {
@@ -150,10 +154,7 @@ Knight.prototype.update = function() {
         }
     }
 
-    if(this.invulnerableFrames > 0) {
-        this.invulnerableFrames--;
-    }
-
+    //Update the Knight's falling state.
     if (this.entity.game.getBottomCollisions(this).length === 0) {
         //If there is no bottom collision, then the agent is in the air, and should accelerate downwards.
         this.yVelocity += KNIGHT_PHYSICS.Y_ACCELERATION;
@@ -218,6 +219,19 @@ Knight.prototype.jump = function() {
     }
     //The player must actively press up to jump, they can't just hold it.
     this.canJump = false;
+}
+
+/**
+  * Request the Knight to rest.
+  */
+Knight.prototype.rest = function () {
+    if(this.attacking) return;
+    if(this.direction === KNIGHT_DIR.RIGHT) {
+        this.entity.setAnimation(KNIGHT_ANIM.STAND_RIGHT);
+    } else {
+        this.entity.setAnimation(KNIGHT_ANIM.STAND_LEFT);
+    }
+    this.slowDown();
 }
 
 /**
@@ -290,13 +304,7 @@ Knight.prototype.readInput = function(input, modifier) {
         }
     }
     if (input === "none") {
-        if(this.attacking) return;
-        if(this.direction === KNIGHT_DIR.RIGHT) {
-            this.entity.setAnimation(KNIGHT_ANIM.STAND_RIGHT);
-        } else {
-            this.entity.setAnimation(KNIGHT_ANIM.STAND_LEFT);
-        }
-        this.slowDown();
+        this.rest();
     }
 
     //Knight can only jump upon pressing jump, so reset the ability to jump
@@ -308,10 +316,10 @@ Knight.prototype.readInput = function(input, modifier) {
     //If right or left aren't being pressed, but the knight is currently running, then reset
     //the knight's animation.
     if(input === "right_released" && this.entity.currentAnimation === KNIGHT_ANIM.WALKING_RIGHT) {
-        this.readInput("none");
+        this.rest();
     }
     if (input === "left_released" && this.entity.currentAnimation === KNIGHT_ANIM.WALKING_LEFT) {
-        this.readInput("none");
+        this.rest();
     }
 
     if (input === "space_released") {

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -151,11 +151,6 @@ Knight.prototype.findYourCenter = function () {
  */
 Knight.prototype.update = function() {
 
-    if (this.health <= 0) {
-        this.health = KNIGHT_ATTR.STARTING_HEALTH;
-        this.entity.game.respawnPlayer(this);
-    }
-
     this.attacking = false;
     var currentAnimation = this.entity.currentAnimation;
 
@@ -361,9 +356,14 @@ Knight.prototype.readInput = function(input, modifier) {
                 this.yVelocity = -6;
             }
         }
+        
+        if (this.health <= 0) {
+            this.entity.removeFromWorld = true;
+        }
     }
     
     if (input === "reset") {
+        this.health = KNIGHT_ATTR.STARTING_HEALTH;
         this.xVelocity = 0;
         this.yVelocity = 0;
     }

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -61,11 +61,6 @@ var KNIGHT_PHYSICS = {
 function Knight(game, AM, x, y) {
     this.entity = new Entity(game, x, y, 48, 50);
 
-    this.centerPoint = {
-        x: (this.entity.x + (this.entity.width) / 2),
-        y: (this.entity.y + (this.entity.height) / 2)
-    }
-
     this.yVelocity = 0;
     this.xVelocity = 0;
     this.direction = KNIGHT_DIR.RIGHT;
@@ -138,13 +133,6 @@ Knight.prototype.draw = function (cameraX, cameraY) {
     ctx.fillRect(20, 20, 500 * percent, 30);
 };
 
-Knight.prototype.findYourCenter = function () {
-    this.centerPoint = {
-        x: (this.entity.x + (this.entity.width) / 2),
-        y: (this.entity.y + (this.entity.height) / 2)
-    }
-}
-
 /**
  * Update the Knight agent.
  */
@@ -161,8 +149,6 @@ Knight.prototype.update = function() {
             this.readInput("none");
         }
     }
-
-    this.findYourCenter();
 
     if(this.invulnerableFrames > 0) {
         this.invulnerableFrames--;

--- a/src/agents/knight.js
+++ b/src/agents/knight.js
@@ -60,16 +60,17 @@ var KNIGHT_PHYSICS = {
  */
 function Knight(game, AM, x, y) {
     this.entity = new Entity(game, x, y, 48, 50);
+    this.swordHitbox = null;
 
     this.yVelocity = 0;
     this.xVelocity = 0;
     this.direction = KNIGHT_DIR.RIGHT;
+    
     this.canJump = true;
-    this.canMove = true;
+    this.attacking = false;
     this.noclip = false;
 
     this.invulnerableFrames = 0;
-    this.attacking = false;
     this.health = KNIGHT_ATTR.STARTING_HEALTH;
 
     var KnightStandRight = new Animation(AM.getAsset("./img/knight/knight standing.png"),
@@ -150,7 +151,7 @@ Knight.prototype.update = function() {
             this.attacking = true;
         } else {
             this.attacking = false;
-            this.readInput("none");
+            this.rest();
         }
     }
 
@@ -168,15 +169,13 @@ Knight.prototype.update = function() {
                this.entity.currentAnimation === KNIGHT_ANIM.JUMPING_LEFT ||
                this.entity.currentAnimation === KNIGHT_ANIM.FALLING_RIGHT ||
                this.entity.currentAnimation === KNIGHT_ANIM.FALLING_LEFT) {
-                   this.readInput("none");
+                   this.rest();
             }
     }
 
-    //If the agent is moving upwards, then it is jumping.
-    //However, currently using jump animation whenever knight is in air.
+    //If the agent is jumping, check for top collisions.
     if(this.yVelocity < 0) {
         if (this.entity.game.getTopCollisions(this).length > 0) {
-            //If a top collision is detected, then the agent has hit a ceiling and must stop rising.
             this.yVelocity = 0;
         }
     }
@@ -187,12 +186,12 @@ Knight.prototype.update = function() {
         if (this.entity.currentAnimation !== KNIGHT_ANIM.ATTACK_LEFT &&
            this.entity.currentAnimation !== KNIGHT_ANIM.ATTACK_RIGHT) {
             
-            if(this.yVelocity > 0) {
-            if(this.direction === KNIGHT_DIR.RIGHT) {
-                this.entity.setAnimation(KNIGHT_ANIM.FALLING_RIGHT);
-            } else {
-                this.entity.setAnimation(KNIGHT_ANIM.FALLING_LEFT);
-            }
+            if (this.yVelocity > 0) {
+                if(this.direction === KNIGHT_DIR.RIGHT) {
+                    this.entity.setAnimation(KNIGHT_ANIM.FALLING_RIGHT);
+                } else {
+                    this.entity.setAnimation(KNIGHT_ANIM.FALLING_LEFT);
+                }
             } else {
                 if(this.direction === KNIGHT_DIR.RIGHT) {
                     this.entity.setAnimation(KNIGHT_ANIM.JUMPING_RIGHT);
@@ -201,12 +200,17 @@ Knight.prototype.update = function() {
                 }
             }
         }
-        
     }
     
     //Move the player independently in both directions, otherwise it will feel off.
     this.entity.game.requestMove(this, this.xVelocity, 0);
     this.entity.game.requestMove(this, 0, this.yVelocity);
+    
+    //Move the sword hitbox with the player.
+    if (this.attacking && this.swordHitbox !== null) {
+        this.entity.game.requestMove(this.swordHitbox, this.xVelocity, 0);
+        this.entity.game.requestMove(this.swordHitbox, 0, this.yVelocity);
+    }
 }
 
 /**
@@ -239,11 +243,11 @@ Knight.prototype.rest = function () {
  */
 Knight.prototype.readInput = function(input, modifier) {
     if (input === "down") {
-        if(!this.canMove) return;
+        if(this.attacking) return;
         this.entity.game.requestMove(this, 0, KNIGHT_PHYSICS.PRESS_DOWN_SPEED);
     }
     if (input === "up") {
-        if(!this.canMove) return;
+        if(this.attacking) return;
         //Add upwards velocity if the player is holding up while jumping.
         if (this.yVelocity < 0) this.yVelocity -= KNIGHT_PHYSICS.PRESS_UP_SPEED;
         this.jump();
@@ -254,7 +258,7 @@ Knight.prototype.readInput = function(input, modifier) {
         }
     }
     if (input === "left") {
-        if(!this.canMove) return;
+        if(this.attacking) return;
         this.direction = KNIGHT_DIR.LEFT;
         if(this.entity.game.getBottomCollisions(this).length > 0) {
             //An agent should only walk if it is not in the air.
@@ -263,17 +267,17 @@ Knight.prototype.readInput = function(input, modifier) {
         if (this.xVelocity >= KNIGHT_PHYSICS.TERMINAL_X_VELOCITY * -1) {
             this.adjustXVelocity(-2);
         } else {
+            //Terminal Velocity is exceeding during knockback, so only slow down here.
             this.slowDown();
         }
     }
+    //Uses the same logic as input left.
     if(input === "right") {
-        if(!this.canMove) return;
+        if(this.attacking) return;
         this.direction = KNIGHT_DIR.RIGHT;
         if(this.entity.game.getBottomCollisions(this).length > 0) {
-            //An agent should only walk if it is not in the air.
             this.entity.setAnimation(KNIGHT_ANIM.WALKING_RIGHT);
         }
-        
         if (this.xVelocity <= KNIGHT_PHYSICS.TERMINAL_X_VELOCITY) {
             this.adjustXVelocity(2);
         } else {
@@ -281,8 +285,6 @@ Knight.prototype.readInput = function(input, modifier) {
         }
     }
     if (input === "space") {
-        //Prevent the player from moving while attacking.
-        this.canMove = false;
         if(this.direction === KNIGHT_DIR.RIGHT) {
             this.entity.setAnimation(KNIGHT_ANIM.ATTACK_RIGHT);
         } else {
@@ -294,13 +296,13 @@ Knight.prototype.readInput = function(input, modifier) {
         if (!this.attacking) {
             this.attacking = true;
             if(this.direction === KNIGHT_DIR.RIGHT) {
-                var newAttack = new SwordHitbox(this.entity.game, this.entity.x + this.entity.width - 29, this.entity.y, this);
+                this.swordHitbox = new SwordHitbox(this.entity.game, this.entity.x + this.entity.width - 29, this.entity.y, this);
             } else {
-                var newAttack = new SwordHitbox(this.entity.game, this.entity.x - this.entity.width + 5,
+                this.swordHitbox = new SwordHitbox(this.entity.game, this.entity.x - this.entity.width + 5,
                                                 this.entity.y, this);
             }
 
-            this.entity.game.addAgent(newAttack);
+            this.entity.game.addAgent(this.swordHitbox);
         }
     }
     if (input === "none") {
@@ -320,12 +322,6 @@ Knight.prototype.readInput = function(input, modifier) {
     }
     if (input === "left_released" && this.entity.currentAnimation === KNIGHT_ANIM.WALKING_LEFT) {
         this.rest();
-    }
-
-    if (input === "space_released") {
-        if (!this.attacking) {
-            this.canMove = true;
-        }
     }
     
     if (input === "left_and_right_released") {
@@ -413,6 +409,7 @@ SwordHitbox.prototype = {
 
     update: function() {
         if (!this.source.attacking) {
+            if (this.source.swordHitbox === this) this.source.swordHitbox = null;
             this.entity.removeFromWorld = true;
         }
         //Does not move the entity, but simply checks if it is currently colliding.

--- a/src/entity.js
+++ b/src/entity.js
@@ -56,6 +56,12 @@ Entity.prototype = {
             this.animationList[this.currentAnimation].elapsedTime = 0;
         }
         this.currentAnimation = animation;
+    },
+    
+    getCenter: function () {
+        return {
+            x: (this.x + (this.width) / 2),
+            y: (this.y + (this.height) / 2)
+        }
     }
-
 }

--- a/src/entity.js
+++ b/src/entity.js
@@ -19,7 +19,6 @@ function Entity(game, x, y, width, height) {
     this.ctx = game.ctx;
     this.controllable = false;
     this.moveable = false;
-    this.fallable = false;
     this.camerable = false;
     this.respawnable = false;
     this.collidable = true;

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -220,15 +220,22 @@ GameEngine.prototype = {
 
     //Entities should check for input when updated here
     update : function () {
-        for (var i = 0; i < this.agents.length; i++) {
+        //Iterate backwards to avoid splice errors.
+        for (var i = this.agents.length - 1; i >= 0; i--) {
+            //If the agent has been flagged for removal, do so; otherwise, update it.
             if (this.agents[i].entity.removeFromWorld) {
                 var removedAgent = this.agents.splice(i, 1)[0];
                 //Save the removed agent for when the level restarts.
                 this.removedAgents.push(removedAgent);
                 removedAgent.entity.removeFromWorld = false;
-                continue;
+                
+                //If the removed agent was the player, then respawn them.
+                if (removedAgent === this.playerAgent) {
+                    this.respawnPlayer();
+                }
+            } else {
+                this.agents[i].update();
             }
-            this.agents[i].update();
         }
 
         this.updateCamera();
@@ -303,8 +310,6 @@ GameEngine.prototype = {
 
     respawnPlayer: function () {
         this.resetStage();
-        //this.playerAgent.entity.x = this.stages[this.currentStage].spawnX;
-        //this.playerAgent.entity.y = this.stages[this.currentStage].spawnY;
     },
 
 

--- a/src/gameengine.js
+++ b/src/gameengine.js
@@ -428,7 +428,7 @@ GameEngine.prototype = {
             if (!xMoveValid && !yMoveValid) {
                 
                 //Temporary fix to allow platforms to move the player.
-                if(other.controllable && other.moveable) {
+                if(other.controllable && other.moveable && !agent.entity.intangible) {
                     this.requestMove(this.agents[i], amountX, amountY);
                     if (agent.entity.pushesOnly) {
                        continue; 

--- a/src/main.js
+++ b/src/main.js
@@ -107,7 +107,6 @@ AM.downloadAll(function () {
     var knight = new Knight(gameEngine, AM, forestStage.spawnX, forestStage.spawnY);
     knight.entity.controllable = true;
     knight.entity.moveable = true;
-    knight.entity.fallable = true;
     knight.entity.camerable = true;
     knight.entity.respawnable = true;
     forestStage.entityList.push(knight);

--- a/txt/forest-stage.txt
+++ b/txt/forest-stage.txt
@@ -34,12 +34,12 @@
                       x                      x               x                       x
                        x                     x                                       x
                         x        xxxxxxxxxxxxxxxxxxxxxxxxx                           x
-              xxx                x                       x                           x
+              xxx                x                       x@                          x
               x x              xxx                       xxxxx                       x
          xx   x x          !   x                             x                       x
               x xxxxxxxxxxxxxxxx                             x                       x
               x                                              x                       x
-@    x     !  x                                              x                       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+     x     !  x                                              x                       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 xxxxxxxxxxxxxxx                                              x                       
                                                              x                       
                                                              x                            

--- a/txt/forest-stage.txt
+++ b/txt/forest-stage.txt
@@ -34,12 +34,12 @@
                       x                      x               x                       x
                        x                     x                                       x
                         x        xxxxxxxxxxxxxxxxxxxxxxxxx                           x
-              xxx                x                       x@                          x
+              xxx                x                       x                           x
               x x              xxx                       xxxxx                       x
          xx   x x          !   x                             x                       x
               x xxxxxxxxxxxxxxxx                             x                       x
               x                                              x                       x
-     x     !  x                                              x                       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+@    x     !  x                                              x                       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 xxxxxxxxxxxxxxx                                              x                       
                                                              x                       
                                                              x                            


### PR DESCRIPTION
Couldn't sleep, so I went ahead and cleaned up the Knight code as much as I could. It's nowhere near what I would like, but it's better. Only functional difference is that the sword hitbox will now move with you, and a very small tweak to forest boss core behavior. Also, the game engine update loop for agents now iterates in reverse to avoid any potential errors caused by splicing.

Oh, and noclip mode is still horribly broken, but it's easier to just move the spawn point around anyway. Remembering to put the spawn point back, on the other hand, is apparently much more difficult.
